### PR TITLE
Hash queries by MonitorQuery instead of BytesRef

### DIFF
--- a/src/main/java/uk/co/flax/luwak/MonitorQuery.java
+++ b/src/main/java/uk/co/flax/luwak/MonitorQuery.java
@@ -1,5 +1,6 @@
 package uk.co.flax.luwak;
 
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.lucene.util.BytesRef;
 
 /**
@@ -23,7 +24,10 @@ import org.apache.lucene.util.BytesRef;
  */
 public class MonitorQuery {
 
+    private static final AtomicLong sequence = new AtomicLong(0);
+
     private final String id;
+    private final long seqId;
     private final BytesRef query;
     private final BytesRef highlightQuery;
 
@@ -35,6 +39,22 @@ public class MonitorQuery {
      */
     public MonitorQuery(String id, BytesRef query, BytesRef highlightQuery) {
         this.id = id;
+        this.seqId = sequence.incrementAndGet();
+        this.query = query;
+        this.highlightQuery = highlightQuery;
+    }
+
+    /**
+     * Creates a new MonitorQuery
+     *
+     * @param id the ID
+     * @param query the query to store
+     * @param highlightQuery an optional query to use for highlighting. May be null.
+     * @param seqId Sequence identifier
+     */
+    public MonitorQuery(String id, BytesRef query, BytesRef highlightQuery, long seqId) {
+        this.id = id;
+        this.seqId = seqId;
         this.query = query;
         this.highlightQuery = highlightQuery;
     }
@@ -48,6 +68,7 @@ public class MonitorQuery {
      */
     public MonitorQuery(String id, String query, String highlightQuery) {
         this.id = id;
+        this.seqId = sequence.incrementAndGet();
         if (query == null) {
             throw new IllegalArgumentException("Null queries are not allowed");
         }
@@ -83,6 +104,13 @@ public class MonitorQuery {
     }
 
     /**
+     * @return Sequence number of a query
+     */
+    public long getSeqId() {
+        return seqId;
+    }
+
+    /**
      * @return this MonitorQuery's highlight query.  May be null.
      */
     public BytesRef getHighlightQuery() {
@@ -96,10 +124,8 @@ public class MonitorQuery {
 
         MonitorQuery that = (MonitorQuery) o;
 
-        if (highlightQuery != null ? !highlightQuery.equals(that.highlightQuery) : that.highlightQuery != null)
-            return false;
         if (id != null ? !id.equals(that.id) : that.id != null) return false;
-        if (query != null ? !query.equals(that.query) : that.query != null) return false;
+        if (seqId != that.seqId) return false;
 
         return true;
     }
@@ -107,8 +133,7 @@ public class MonitorQuery {
     @Override
     public int hashCode() {
         int result = id != null ? id.hashCode() : 0;
-        result = 31 * result + (query != null ? query.hashCode() : 0);
-        result = 31 * result + (highlightQuery != null ? highlightQuery.hashCode() : 0);
+        result = 31 * result + (int)seqId;
         return result;
     }
 }

--- a/src/main/java/uk/co/flax/luwak/QueryCache.java
+++ b/src/main/java/uk/co/flax/luwak/QueryCache.java
@@ -17,10 +17,9 @@ package uk.co.flax.luwak;
  */
 
 import org.apache.lucene.search.Query;
-import org.apache.lucene.util.BytesRef;
 
 public interface QueryCache {
 
-    Query get(BytesRef query) throws QueryCacheException;
+    QueryCacheEntry get(MonitorQuery mq) throws QueryCacheException;
 
 }

--- a/src/main/java/uk/co/flax/luwak/QueryCacheEntry.java
+++ b/src/main/java/uk/co/flax/luwak/QueryCacheEntry.java
@@ -1,0 +1,24 @@
+package uk.co.flax.luwak;
+
+import org.apache.lucene.search.Query;
+
+public class QueryCacheEntry {
+
+    private final Query query;
+    private final Query highlightQuery;
+
+    public QueryCacheEntry(Query query, Query highlightQuery) {
+        this.query = query;
+        this.highlightQuery = highlightQuery;
+    }
+
+    public Query getQuery() {
+        return query;
+    }
+
+    public Query getHighlightQuery() {
+        return highlightQuery;
+    }
+
+    
+}

--- a/src/test/java/uk/co/flax/luwak/TestMonitor.java
+++ b/src/test/java/uk/co/flax/luwak/TestMonitor.java
@@ -11,6 +11,7 @@ import uk.co.flax.luwak.parsers.LuceneQueryCache;
 import uk.co.flax.luwak.presearcher.MatchAllPresearcher;
 
 import java.io.IOException;
+import org.apache.lucene.util.BytesRef;
 
 import static uk.co.flax.luwak.util.MatchesAssert.assertThat;
 
@@ -99,11 +100,12 @@ public class TestMonitor {
     @Test
     public void canRetrieveQuery() throws IOException {
 
-        monitor.update(new MonitorQuery("query1", "this"), new MonitorQuery("query2", "that", "hl"));
+        monitor.update(new MonitorQuery("query1", "this"),
+                new MonitorQuery("query2", new BytesRef("that"), new BytesRef("hl"), 5));
         Assertions.assertThat(monitor.getQueryCount()).isEqualTo(2);
 
         MonitorQuery mq = monitor.getQuery("query2");
-        Assertions.assertThat(mq).isEqualTo(new MonitorQuery("query2", "that", "hl"));
+        Assertions.assertThat(mq).isEqualTo(new MonitorQuery("query2", new BytesRef("that"), new BytesRef("hl"), 5));
 
     }
 

--- a/src/test/java/uk/co/flax/luwak/TestParsingQueryCache.java
+++ b/src/test/java/uk/co/flax/luwak/TestParsingQueryCache.java
@@ -28,8 +28,8 @@ public class TestParsingQueryCache {
     @Test
     public void testQueryOnlyParsesOnce() throws QueryCacheException {
         LuceneQueryCache cache = new LuceneQueryCache("f");
-        Query query1 = cache.get(new BytesRef("test"));
-        Query query2 = cache.get(new BytesRef("test"));
+        QueryCacheEntry query1 = cache.get(new MonitorQuery("1", new BytesRef("test"), null, 10));
+        QueryCacheEntry query2 = cache.get(new MonitorQuery("1", new BytesRef("test"), null, 10));
 
         assertThat(query1).isSameAs(query2);
     }
@@ -43,7 +43,7 @@ public class TestParsingQueryCache {
 
         expected.expect(QueryCacheException.class);
         expected.expectMessage("Was expecting one of");
-        cache.get(new BytesRef("test (+hello"));
+        cache.get(new MonitorQuery("id", "test (+hello"));
     }
 
 }


### PR DESCRIPTION
Also change equals method in MonitorQuery. This will speed up query cache.
