### PR TITLE
Clear attributes in incrementToken to fix IllegalArgumentException.

### DIFF
--- a/src/main/java/uk/co/flax/luwak/analysis/TermsEnumTokenStream.java
+++ b/src/main/java/uk/co/flax/luwak/analysis/TermsEnumTokenStream.java
@@ -38,6 +38,8 @@ public class TermsEnumTokenStream extends TokenStream {
 
     @Override
     public final boolean incrementToken() throws IOException {
+    	clearAttributes();
+    	
         BytesRef bytes = termsEnum.next();
         if (bytes == null)
             return false;


### PR DESCRIPTION
We ran into IllegalArgumentException for an uninitialized position increment. Adding clearAttributes call to incrementToken solved this problem for us.

```
java.lang.IllegalArgumentException: Increment must be zero or greater: -1873026560 
at org.apache.lucene.analysis.tokenattributes.PackedTokenAttributeImpl.setPositionIncrement(PackedTokenAttributeImpl.java:50) 
at org.apache.lucene.analysis.util.FilteringTokenFilter.incrementToken(FilteringTokenFilter.java:58) 
at uk.co.flax.luwak.presearcher.TermFilteredPresearcher.buildQuery(TermFilteredPresearcher.java:80) 
at uk.co.flax.luwak.Monitor.buildQuery(Monitor.java:174) 
at uk.co.flax.luwak.Monitor.match(Monitor.java:162) 
at uk.co.flax.luwak.Monitor.match(Monitor.java:189) 
...
```
