### PR TITLE
Add getQueryIds API to Monitor

### DIFF
--- a/luwak/src/main/java/uk/co/flax/luwak/Monitor.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/Monitor.java
@@ -546,6 +546,13 @@ public class Monitor implements Closeable {
      * @throws java.io.IOException on IO errors
      */
     public int getQueryCount() throws IOException {
+        return getQueryIds().size();
+    }
+
+    /**
+     * @return the set of query ids of the queries stored in this Monitor
+     */
+    public Set<String> getQueryIds() throws IOException {
         final Set<String> ids = new HashSet<>();
         match(new MatchAllDocsQuery(), new MonitorQueryCollector() {
             @Override
@@ -553,7 +560,7 @@ public class Monitor implements Closeable {
                 ids.add(queryId);
             }
         });
-        return ids.size();
+        return ids;
     }
 
     /**

--- a/luwak/src/test/java/uk/co/flax/luwak/TestMonitor.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/TestMonitor.java
@@ -119,6 +119,7 @@ public class TestMonitor {
 
         monitor.update(new MonitorQuery("query1", "this"), new MonitorQuery("query2", "that", "hl"));
         Assertions.assertThat(monitor.getQueryCount()).isEqualTo(2);
+        Assertions.assertThat(monitor.getQueryIds()).contains("query1", "query2");
 
         MonitorQuery mq = monitor.getQuery("query2");
         Assertions.assertThat(mq).isEqualTo(new MonitorQuery("query2", "that", "hl"));


### PR DESCRIPTION
This just re-uses the code from `getQueryCount()` but returns the Set of (formatted) query Ids to the user.  Only really for debugging purposes, and in reality `getQuery(id)` is the more useful API, but I can see no harm in this, other than it will potentially return a large Set.  Cost-wise it is just as expensive as `getQueryCount()`