### PR TITLE
Add some Index stats to monitor

### DIFF
--- a/luwak/src/main/java/uk/co/flax/luwak/Monitor.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/Monitor.java
@@ -147,7 +147,7 @@ public class Monitor implements Closeable {
         /** Total number of queries in the query index */
         public final int queries;
 
-        /** Total number of queries int the query cache */
+        /** Total number of queries in the query cache */
         public final int cachedQueries;
 
         /** Time the query cache was last purged */
@@ -157,6 +157,31 @@ public class Monitor implements Closeable {
             this.queries = queries;
             this.cachedQueries = cachedQueries;
             this.lastPurged = lastPurged;
+        }
+    }
+
+    /**
+     * Statistics for the query index
+     */
+    public static class IndexStats {
+
+        /** Number of documents in RAM waiting to be committed */
+        public final int ramDocs;
+
+        /** Total number of bytes used in memory */
+        public final long ramBytes;
+
+        /** Segment info as a string */
+        public final String segmentString;
+
+        /** Directory of the index (for caller to calculate size) */
+        public final Directory indexDirectory;
+
+        public IndexStats(int ramDocs, long ramBytes, String segmentString, Directory indexDirectory) {
+            this.ramDocs = ramDocs;
+            this.ramBytes = ramBytes;
+            this.segmentString = segmentString;
+            this.indexDirectory = indexDirectory;
         }
     }
 
@@ -199,6 +224,13 @@ public class Monitor implements Closeable {
      */
     public CacheStats getStats() {
         return new CacheStats(this.writer.numDocs(), this.queries.size(), lastPurged);
+    }
+
+    /**
+     * @return Statistics for the internal query index
+     */
+    public IndexStats getIndexStats() {
+        return new IndexStats(this.writer.numRamDocs(), this.writer.ramBytesUsed(), this.writer.segString(), this.writer.getDirectory());
     }
 
     private void commit(List<CacheEntry> updates) throws IOException {

--- a/luwak/src/test/java/uk/co/flax/luwak/TestCachePurging.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/TestCachePurging.java
@@ -62,10 +62,12 @@ public class TestCachePurging {
             monitor.deleteById("1");
             assertThat(monitor.getQueryCount()).isEqualTo(2);
             assertThat(monitor.getStats().cachedQueries).isEqualTo(4);
+            assertThat(monitor.getIndexStats().segmentString).isNotEmpty();
             assertThat(monitor.match(doc, SimpleMatcher.FACTORY).getMatchCount()).isEqualTo(2);
 
             monitor.purgeCache();
             assertThat(monitor.getStats().cachedQueries).isEqualTo(2);
+            assertThat(monitor.getIndexStats().segmentString).isNotEmpty();
 
             Matches<QueryMatch> result = monitor.match(doc, SimpleMatcher.FACTORY);
             assertThat(result.getMatchCount()).isEqualTo(2);
@@ -122,11 +124,13 @@ public class TestCachePurging {
                 finishUpdating.await();
 
                 assertThat(monitor.getStats().cachedQueries).isEqualTo(340);
+                assertThat(monitor.getIndexStats().segmentString).isNotEmpty();
                 InputDocument doc = InputDocument.builder("doc1")
                         .addField("field", "test", new WhitespaceAnalyzer()).build();
                 Matches<QueryMatch> matcher = monitor.match(doc, SimpleMatcher.FACTORY);
                 assertThat(matcher.getErrors()).isEmpty();
                 assertThat(matcher.getMatchCount()).isEqualTo(340);
+                assertThat(monitor.getIndexStats().segmentString).isNotEmpty();
             }
             finally {
                 executor.shutdownNow();
@@ -161,6 +165,7 @@ public class TestCachePurging {
             assertThat(monitor.getStats().queries).isEqualTo(99);
             assertThat(monitor.getStats().cachedQueries).isEqualTo(99);
             assertThat(monitor.getStats().lastPurged).isGreaterThan(0);
+            assertThat(monitor.getIndexStats().segmentString).isNotEmpty();
         }
     }
 }


### PR DESCRIPTION
This was the beginning of some debug work we used to investigate issues we were seeing, we wanted to more easily be able to see how the index grew over time, including with merges, etc.

We used Solr's `DirectoryFactory.sizeOfDirectory()` in our calling code, which is why we return the raw Directory here. I don't think that is dangerous, but there is the question of what **else** the caller could do with the Directory once they have access to it.  We could just copy that code into Luwak (its relatively trivial)?