### PR TITLE
multiple code improvements: squid:S1118, squid:S00116, squid:S1213, squid:S1155

### DIFF
--- a/benchmark/src/main/java/uk/co/flax/luwak/benchmark/Benchmark.java
+++ b/benchmark/src/main/java/uk/co/flax/luwak/benchmark/Benchmark.java
@@ -25,6 +25,8 @@ import uk.co.flax.luwak.*;
 
 public class Benchmark {
 
+    private Benchmark() {}
+
     public static <T extends QueryMatch> BenchmarkResults<T> run(Monitor monitor, Iterable<InputDocument> documents,
                                                                  int batchsize, MatcherFactory<T> matcherFactory) throws IOException {
         BenchmarkResults<T> results = new BenchmarkResults<>();

--- a/benchmark/src/main/java/uk/co/flax/luwak/benchmark/BenchmarkResults.java
+++ b/benchmark/src/main/java/uk/co/flax/luwak/benchmark/BenchmarkResults.java
@@ -30,9 +30,9 @@ import uk.co.flax.luwak.QueryMatch;
 
 public class BenchmarkResults<T extends QueryMatch> {
 
-    private final MetricRegistry METRICS = new MetricRegistry();
-    private final Timer timer = METRICS.timer("searchTimes");
-    private final Histogram queryBuildTimes = METRICS.histogram("queryBuildTimes");
+    private final MetricRegistry metrics = new MetricRegistry();
+    private final Timer timer = metrics.timer("searchTimes");
+    private final Histogram queryBuildTimes = metrics.histogram("queryBuildTimes");
 
     public void add(Matches<T> benchmarkMatches) {
         timer.update(benchmarkMatches.getSearchTime(), TimeUnit.MILLISECONDS);
@@ -48,7 +48,7 @@ public class BenchmarkResults<T extends QueryMatch> {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         try {
             PrintStream out = new PrintStream(os, true, StandardCharsets.UTF_8.name());
-            ConsoleReporter.forRegistry(METRICS).outputTo(out).build().report();
+            ConsoleReporter.forRegistry(metrics).outputTo(out).build().report();
             return os.toString(StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);

--- a/benchmark/src/main/java/uk/co/flax/luwak/benchmark/PresearcherMatcher.java
+++ b/benchmark/src/main/java/uk/co/flax/luwak/benchmark/PresearcherMatcher.java
@@ -31,6 +31,13 @@ import uk.co.flax.luwak.MatcherFactory;
  */
 public class PresearcherMatcher extends CandidateMatcher<PresearcherMatch> {
 
+    public static final MatcherFactory<PresearcherMatch> FACTORY = new MatcherFactory<PresearcherMatch>() {
+        @Override
+        public CandidateMatcher<PresearcherMatch> createMatcher(DocumentBatch docs) {
+            return new PresearcherMatcher(docs);
+        }
+    };
+
     public PresearcherMatcher(DocumentBatch batch) {
         super(batch);
     }
@@ -47,10 +54,4 @@ public class PresearcherMatcher extends CandidateMatcher<PresearcherMatch> {
         return match1;
     }
 
-    public static final MatcherFactory<PresearcherMatch> FACTORY = new MatcherFactory<PresearcherMatch>() {
-        @Override
-        public CandidateMatcher<PresearcherMatch> createMatcher(DocumentBatch docs) {
-            return new PresearcherMatcher(docs);
-        }
-    };
 }

--- a/benchmark/src/main/java/uk/co/flax/luwak/benchmark/ValidatorResults.java
+++ b/benchmark/src/main/java/uk/co/flax/luwak/benchmark/ValidatorResults.java
@@ -47,7 +47,7 @@ public class ValidatorResults<T extends QueryMatch> extends BenchmarkResults<T> 
         Sets.SetView<T> extras = Sets.difference(expectedMatches, actualMatches);
         Sets.SetView<T> missing = Sets.difference(actualMatches, expectedMatches);
 
-        if (extras.size() == 0 && missing.size() == 0)
+        if (extras.isEmpty() && missing.isEmpty())
             correctMatches++;
         else {
             missingMatches.putAll(docMatches.getDocId(), missing);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 Utility classes should not have public constructors.
squid:S00116 Field names should comply with a naming convention.
squid:S1213 The members of an interface declaration or class should appear in a pre-defined order.
squid:S1155 Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1118
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00116
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1155
Please let me know if you have any questions.
George Kankava