### PR TITLE
multiple code improvements: squid:S1118, squid:S1155, squid:S1125, squid:S2864, squid:S1213

### DIFF
--- a/luwak/src/main/java/org/apache/lucene/search/spans/SpanExtractor.java
+++ b/luwak/src/main/java/org/apache/lucene/search/spans/SpanExtractor.java
@@ -28,6 +28,8 @@ import org.apache.lucene.search.Scorer;
  */
 public class SpanExtractor {
 
+    private SpanExtractor() {}
+
     /**
      * Get a list of all Spans made available from the passed-in Scorer
      * @param scorer the scorer to extract spans from
@@ -44,7 +46,7 @@ public class SpanExtractor {
         }
 
         Collection<Scorer.ChildScorer> children = scorer.getChildren();
-        if (errorOnNoSpans && children.size() == 0)
+        if (errorOnNoSpans && children.isEmpty())
             throw new RuntimeException("Couldn't extract SpanScorer from " + scorer.getClass().getCanonicalName());
 
         for (Scorer.ChildScorer child : children) {

--- a/luwak/src/main/java/org/apache/lucene/search/spans/SpanRewriter.java
+++ b/luwak/src/main/java/org/apache/lucene/search/spans/SpanRewriter.java
@@ -100,8 +100,8 @@ public class SpanRewriter {
                 spanQueries.get(it.field()).add(new SpanTermQuery(new Term(it.field(), term)));
             }
             BooleanQuery.Builder builder = new BooleanQuery.Builder();
-            for (String field : spanQueries.keySet()) {
-                List<SpanTermQuery> termQueries = spanQueries.get(field);
+            for (Map.Entry<String,List<SpanTermQuery>> entry : spanQueries.entrySet()) {
+                List<SpanTermQuery> termQueries = entry.getValue();
                 builder.add(new SpanOrQuery(termQueries.toArray(new SpanTermQuery[termQueries.size()])),
                         BooleanClause.Occur.SHOULD);
             }

--- a/luwak/src/main/java/uk/co/flax/luwak/termextractor/QueryAnalyzer.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/termextractor/QueryAnalyzer.java
@@ -82,6 +82,16 @@ public class QueryAnalyzer {
     }
 
     /**
+     * Create a QueryAnalyzer using the default TreeWeightor, and the provided QueryTreeBuilders,
+     * in addition to the default set
+     *
+     * @param queryTreeBuilders QueryTreeBuilders used to analyze queries
+     */
+    public QueryAnalyzer(QueryTreeBuilder<?>... queryTreeBuilders) {
+        this(TreeWeightor.DEFAULT_WEIGHTOR, queryTreeBuilders);
+    }
+
+    /**
      * Build a new QueryAnalyzer using a TreeWeightor and a list of PresearcherComponents
      *
      * A list of QueryTreeBuilders is extracted from each component, and combined to use
@@ -110,16 +120,6 @@ public class QueryAnalyzer {
      */
     public static QueryAnalyzer fromComponents(PresearcherComponent... components) {
         return fromComponents(TreeWeightor.DEFAULT_WEIGHTOR, components);
-    }
-
-    /**
-     * Create a QueryAnalyzer using the default TreeWeightor, and the provided QueryTreeBuilders,
-     * in addition to the default set
-     *
-     * @param queryTreeBuilders QueryTreeBuilders used to analyze queries
-     */
-    public QueryAnalyzer(QueryTreeBuilder<?>... queryTreeBuilders) {
-        this(TreeWeightor.DEFAULT_WEIGHTOR, queryTreeBuilders);
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 Utility classes should not have public constructors.
squid:S1155 Collection.isEmpty() should be used to test for emptiness.
squid:S1125 Literal boolean values should not be used in condition expressions.
squid:S2864 "entrySet()" should be iterated when both the key and value are needed.
squid:S1213 The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1118
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1155
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1125
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2864
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
Please let me know if you have any questions.
George Kankava