### PR TITLE
multiple code improvements: squid:S00122, squid:UselessParenthesesCheck

### DIFF
--- a/luwak/src/main/java/uk/co/flax/luwak/termextractor/QueryTerm.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/termextractor/QueryTerm.java
@@ -79,21 +79,31 @@ public class QueryTerm {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         QueryTerm queryTerm = (QueryTerm) o;
 
-        if (term != null ? !term.equals(queryTerm.term) : queryTerm.term != null) return false;
-        if (type != null ? !type.equals(queryTerm.type) : queryTerm.type != null) return false;
-        if (payload != null ? !payload.equals(queryTerm.payload) : queryTerm.payload != null) return false;
+        if (term != null ? !term.equals(queryTerm.term) : queryTerm.term != null) {
+            return false;
+        }
+        if (type != null ? !type.equals(queryTerm.type) : queryTerm.type != null) {
+            return false;
+        }
+        if (payload != null ? !payload.equals(queryTerm.payload) : queryTerm.payload != null) {
+            return false;
+        }
 
         return true;
     }
 
     @Override
     public int hashCode() {
-        int result = (term != null ? term.hashCode() : 0);
+        int result = term != null ? term.hashCode() : 0;
         result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (payload != null ? payload.hashCode() : 0);
         return result;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00122 Statements should be on separate lines.
squid:UselessParenthesesCheck Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00122
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AUselessParenthesesCheck
Please let me know if you have any questions.
George Kankava