### PR TITLE
Implement hashCode() in HighlightsMatch.Hit

### DIFF
--- a/luwak/src/main/java/uk/co/flax/luwak/matchers/HighlightsMatch.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/matchers/HighlightsMatch.java
@@ -142,6 +142,7 @@ public class HighlightsMatch extends QueryMatch {
 
         @Override
         public boolean equals(Object obj) {
+            if (this == obj) return true;
             if (!(obj instanceof Hit))
                 return false;
             Hit other = (Hit) obj;
@@ -149,6 +150,15 @@ public class HighlightsMatch extends QueryMatch {
                     this.endOffset == other.endOffset &&
                     this.startPosition == other.startPosition &&
                     this.endPosition == other.endPosition;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = startPosition;
+            result = 31 * result + startOffset;
+            result = 31 * result + endPosition;
+            result = 31 * result + endOffset;
+            return result;
         }
 
         @Override


### PR DESCRIPTION
HighlightsMatch.Hit didn't define hashCode() but did define equals().
This causes problems if you want to put HighlightsMatch objects into a
collection and breaks the hashCode()/equals() contract, so this commit
adds an implementation of hashCode() that is compatible with the
existing equals().