### PR TITLE
Allow HighlightingMatcher to deal with quoted phrases in queries

### DIFF
--- a/luwak/src/test/java/uk/co/flax/luwak/matchers/TestHighlightingMatcher.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/matchers/TestHighlightingMatcher.java
@@ -75,7 +75,23 @@ public class TestHighlightingMatcher {
                 .matchesQuery("query1", "doc1")
                     .inField(textfield)
                         .withHit(new HighlightsMatch.Hit(3, 10, 3, 14));
+    }
 
+    @Test
+    public void singlePhraseQueryMatchesSingleDocument() throws IOException {
+
+        MonitorQuery mq = new MonitorQuery("query1", "\"test document\"");
+        monitor.update(mq);
+
+        Matches<HighlightsMatch> matcher = monitor.match(buildDoc("doc1", "this is a test document"),
+                HighlightingMatcher.FACTORY);
+
+        assertThat(matcher)
+                .hasMatchCount("doc1", 1)
+                .matchesQuery("query1", "doc1")
+                .inField(textfield)
+                .withHit(new HighlightsMatch.Hit(3, 10, 3, 14))
+                .withHit(new HighlightsMatch.Hit(4, 15, 4, 23));
     }
 
     @Test
@@ -88,7 +104,6 @@ public class TestHighlightingMatcher {
 
         Assertions.assertThat(match.toString())
                 .isEqualTo("Match(doc=1,query=1){hits={afield=[0(0)->1(4)], field=[0(-1)->1(-1), 2(-1)->3(-1)]}}");
-
     }
 
     @Test
@@ -110,7 +125,6 @@ public class TestHighlightingMatcher {
                         .withHit(new HighlightsMatch.Hit(3, 10, 3, 14))
                     .inField("field2")
                         .withHit(new HighlightsMatch.Hit(5, 26, 5, 30));
-
     }
 
     @Test
@@ -175,7 +189,6 @@ public class TestHighlightingMatcher {
                 .hasMatchCount("1", 1);
 
         Assertions.assertThat(matches.matches("1", "1").getHitCount()).isEqualTo(1);
-
     }
 
     @Test
@@ -199,7 +212,6 @@ public class TestHighlightingMatcher {
         assertThat(matches)
                 .matchesQuery("1", "1")
                 .withHitCount(2);
-
     }
 
     @Test
@@ -275,7 +287,6 @@ public class TestHighlightingMatcher {
 
         matches = monitor.match(buildDoc("1", "term2 term"), HighlightingMatcher.FACTORY);
         assertThat(matches).matchesQuery("1", "1").withHitCount(1);
-
     }
 
     @Test
@@ -318,7 +329,5 @@ public class TestHighlightingMatcher {
 
         Assertions.assertThat(m1).isNotEqualTo(m3);
         Assertions.assertThat(m1).isNotEqualTo(m4);
-
     }
-
 }

--- a/luwak/src/test/java/uk/co/flax/luwak/util/TestSpanRewriter.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/util/TestSpanRewriter.java
@@ -18,6 +18,9 @@ package uk.co.flax.luwak.util;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.TermsQuery;
 import org.apache.lucene.search.*;
+import org.apache.lucene.search.spans.SpanNearQuery;
+import org.apache.lucene.search.spans.SpanQuery;
+import org.apache.lucene.search.spans.SpanTermQuery;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,7 +34,6 @@ public class TestSpanRewriter {
 
         Query q = new SpanRewriter().rewrite(tq);
         assertThat(q).isInstanceOf(BooleanQuery.class);
-
     }
 
     @Test
@@ -39,7 +41,6 @@ public class TestSpanRewriter {
 
         Query q = new SpanRewriter().rewrite(new BoostQuery(new TermQuery(new Term("f", "t")), 2.0f));
         assertThat(q).isInstanceOf(SpanOffsetReportingQuery.class);
-
     }
 
     @Test
@@ -50,7 +51,19 @@ public class TestSpanRewriter {
         Query q2 = new SpanRewriter().rewrite(wq);
 
         assertThat(q1).isEqualTo(q2);
-
     }
 
+    @Test
+    public void testPhraseQuery() {
+
+        PhraseQuery pq = new PhraseQuery(1, "field1", "term1", "term2");
+
+        Query q = new SpanRewriter().rewrite(pq);
+        assertThat(q).isInstanceOf(SpanNearQuery.class);
+
+        SpanNearQuery sq = (SpanNearQuery)q;
+        assertThat(sq.getClauses()).contains(new SpanTermQuery(new Term("field1", "term1")),
+                new SpanTermQuery(new Term("field1", "term2")));
+        assertThat(sq.getSlop()).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
Currently the SpanRewriter can't deal with PhraseQuery objects so a query like TEXT:"bomb making" would fail to return any matches if run through HighlightingMatcher - but would return matches with SimpleMatcher.