### PR TITLE
getMatches to get all matches as a collection

### DIFF
--- a/luwak/src/main/java/uk/co/flax/luwak/Matches.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/Matches.java
@@ -73,6 +73,13 @@ public class Matches<T extends QueryMatch> implements Iterable<DocumentMatches<T
     }
 
     /**
+    * @return all matches as a collection
+    */
+    public Collection<DocumentMatches<T>> getMatches() {
+        return matches.values();
+    }
+    
+    /**
      * @return all matches for a particular document
      */
     public DocumentMatches<T> getMatches(String docId) {


### PR DESCRIPTION
Currently it's only possible to get all matches as an iterator, but it would be convenient to get the collection of matches directly.