### PR TITLE
Fix some warnings and issues with deprecated/moved classes

### DIFF
--- a/luwak/src/main/java/uk/co/flax/luwak/Matches.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/Matches.java
@@ -92,7 +92,7 @@ public class Matches<T extends QueryMatch> implements Iterable<DocumentMatches<T
      * @return the number of queries that matched for a given document
      */
     public int getMatchCount(String docId) {
-        DocumentMatches docMatches = matches.get(docId);
+        DocumentMatches<T> docMatches = matches.get(docId);
         if (docMatches == null)
             return 0;
         return docMatches.getMatches().size();

--- a/luwak/src/main/java/uk/co/flax/luwak/UpdateException.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/UpdateException.java
@@ -24,6 +24,8 @@ import java.util.List;
  */
 public class UpdateException extends Exception {
 
+    private static final long serialVersionUID = -2701284159561061331L;
+
     /**
      * The list of errors thrown during an update
      */

--- a/luwak/src/main/java/uk/co/flax/luwak/analysis/BytesRefFilteredTokenFilter.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/analysis/BytesRefFilteredTokenFilter.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
-import org.apache.lucene.analysis.util.FilteringTokenFilter;
+import org.apache.lucene.analysis.FilteringTokenFilter;
 import org.apache.lucene.util.BytesRefHash;
 
 /**

--- a/luwak/src/main/java/uk/co/flax/luwak/analysis/SuffixingNGramTokenFilter.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/analysis/SuffixingNGramTokenFilter.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.*;
-import org.apache.lucene.analysis.util.CharArraySet;
+import org.apache.lucene.analysis.CharArraySet;
 
 /*
  * Copyright (c) 2014 Lemur Consulting Ltd.

--- a/luwak/src/main/java/uk/co/flax/luwak/util/RewriteException.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/util/RewriteException.java
@@ -23,6 +23,8 @@ import org.apache.lucene.search.Query;
  */
 public class RewriteException extends Exception {
 
+    private static final long serialVersionUID = -82604657523783759L;
+
     public final Query cause;
 
     public RewriteException(String message, Query cause) {


### PR DESCRIPTION
Couple of classes were moved in Lucene 6.2.0, we are using the deprecated versions, so updated to  use the new locations since we are on 6.3.0 now.

Not sure what the convention is for serialVersionUID?  I just let Eclipse auto-generate one, but I'm open to other alternatives.