### PR TITLE
Simplify map computing and empty list fix

### DIFF
--- a/luwak/src/main/java/uk/co/flax/luwak/CandidateMatcher.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/CandidateMatcher.java
@@ -80,8 +80,9 @@ public abstract class CandidateMatcher<T extends QueryMatch> {
 
     private void addMatch(String queryId, String docId, T match) {
         MatchHolder<T> docMatches = matches.computeIfAbsent(docId, k -> new MatchHolder<>());
-        if (docMatches.matches.containsKey(queryId)) {
-            docMatches.matches.put(queryId, resolve(match, docMatches.matches.get(queryId)));
+        T found = docMatches.matches.get(queryId);
+        if (found != null) {
+            docMatches.matches.put(queryId, resolve(match, found));
         }
         else {
             docMatches.matches.put(queryId, match);
@@ -151,8 +152,9 @@ public abstract class CandidateMatcher<T extends QueryMatch> {
         Map<String, DocumentMatches<T>> results = new HashMap<>();
         for (InputDocument doc : docs) {
             String id = doc.getId();
-            if (matches.containsKey(id))
-                results.put(id, new DocumentMatches<>(id, matches.get(id).matches.values()));
+            MatchHolder<T> matchHolder = matches.get(id);
+            if (matchHolder != null)
+                results.put(id, new DocumentMatches<>(id, matchHolder.matches.values()));
             else
                 results.put(id, DocumentMatches.noMatches(id));
         }

--- a/luwak/src/main/java/uk/co/flax/luwak/CandidateMatcher.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/CandidateMatcher.java
@@ -80,13 +80,12 @@ public abstract class CandidateMatcher<T extends QueryMatch> {
 
     private void addMatch(String queryId, String docId, T match) {
         MatchHolder<T> docMatches = matches.computeIfAbsent(docId, k -> new MatchHolder<>());
-        T found = docMatches.matches.get(queryId);
-        if (found != null) {
-            docMatches.matches.put(queryId, resolve(match, found));
-        }
-        else {
-            docMatches.matches.put(queryId, match);
-        }
+        docMatches.matches.compute(queryId, (key, oldValue) -> {
+            if (oldValue != null) {
+                return resolve(match, oldValue);
+            }
+            return match;
+        });
     }
 
     /**

--- a/luwak/src/main/java/uk/co/flax/luwak/Monitor.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/Monitor.java
@@ -624,9 +624,7 @@ public class Monitor implements Closeable {
             SpanCollector collector = new SpanCollector() {
                 @Override
                 public void collectLeaf(PostingsEnum postingsEnum, int position, Term term) throws IOException {
-                    if (!matchingTerms.containsKey(id))
-                        matchingTerms.put(id, new StringBuilder());
-                    matchingTerms.get(id)
+                    matchingTerms.computeIfAbsent(id, i -> new StringBuilder())
                             .append(" ")
                             .append(term.field())
                             .append(":")

--- a/luwak/src/main/java/uk/co/flax/luwak/QueryTermFilter.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/QueryTermFilter.java
@@ -64,8 +64,10 @@ public class QueryTermFilter {
      * @return a {@link BytesRefHash} containing all terms for the specified field
      */
     public BytesRefHash getTerms(String field) {
-        if (termsHash.containsKey(field))
-            return termsHash.get(field);
+        BytesRefHash existing = termsHash.get(field);
+        if (existing != null)
+            return existing;
+
         return new BytesRefHash();
     }
 }

--- a/luwak/src/main/java/uk/co/flax/luwak/matchers/HighlightsMatch.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/matchers/HighlightsMatch.java
@@ -69,9 +69,10 @@ public class HighlightsMatch extends QueryMatch {
      * @return the Hits found in this field
      */
     public Collection<Hit> getHits(String field) {
-        if (hits.containsKey(field))
-            return Collections.unmodifiableCollection(hits.get(field));
-        return new LinkedList<>();
+        Collection<Hit> found = hits.get(field);
+        if (found != null)
+            return Collections.unmodifiableCollection(found);
+        return Collections.emptyList();
     }
 
     /**
@@ -90,9 +91,8 @@ public class HighlightsMatch extends QueryMatch {
         for (HighlightsMatch match : matches) {
             assert newMatch.getDocId().equals(match.getDocId());
             for (String field : match.getFields()) {
-                if (!newMatch.hits.containsKey(field))
-                    newMatch.hits.put(field, new TreeSet<Hit>());
-                newMatch.hits.get(field).addAll(match.getHits(field));
+                Set<Hit> hitSet = newMatch.hits.computeIfAbsent(field, f->new TreeSet<>());
+                hitSet.addAll(match.getHits(field));
             }
         }
         return newMatch;
@@ -126,9 +126,8 @@ public class HighlightsMatch extends QueryMatch {
     }
 
     void addHit(String field, int startPos, int endPos, int startOffset, int endOffset) {
-        if (!hits.containsKey(field))
-            hits.put(field, new TreeSet<>());
-        hits.get(field).add(new Hit(startPos, startOffset, endPos, endOffset));
+        Set<Hit> hitSet = hits.computeIfAbsent(field, f->new TreeSet<>());
+        hitSet.add(new Hit(startPos, startOffset, endPos, endOffset));
     }
 
     /**

--- a/luwak/src/main/java/uk/co/flax/luwak/presearcher/PresearcherMatches.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/presearcher/PresearcherMatches.java
@@ -33,8 +33,9 @@ public class PresearcherMatches<T extends QueryMatch> implements Iterable<Presea
     }
 
     public PresearcherMatch<T> match(String queryId, String docId) {
-        if (matchingTerms.containsKey(queryId))
-            return new PresearcherMatch<>(queryId, matchingTerms.get(queryId).toString(), matcher.matches(queryId, docId));
+        StringBuilder found = matchingTerms.get(queryId);
+        if (found != null)
+            return new PresearcherMatch<>(queryId, found.toString(), matcher.matches(queryId, docId));
         return null;
     }
 

--- a/luwak/src/main/java/uk/co/flax/luwak/presearcher/TermFilteredPresearcher.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/presearcher/TermFilteredPresearcher.java
@@ -206,21 +206,15 @@ public class TermFilteredPresearcher extends Presearcher {
 
         for (QueryTerm queryTerm : extractor.collectTerms(tree)) {
             if (queryTerm.type.equals(QueryTerm.Type.ANY)) {
-                if (!fieldTerms.containsKey(ANYTOKEN_FIELD)) {
+                fieldTerms.computeIfAbsent(ANYTOKEN_FIELD, f -> {
                     BytesRefHash hash = new BytesRefHash();
                     hash.add(new BytesRef(ANYTOKEN));
-                    fieldTerms.put(ANYTOKEN_FIELD, hash);
-                }
-            }
-            else {
-                if (!fieldTerms.containsKey(queryTerm.term.field()))
-                    fieldTerms.put(queryTerm.term.field(), new BytesRefHash());
-
-                BytesRefHash termslist = fieldTerms.get(queryTerm.term.field());
-                if (queryTerm.type.equals(QueryTerm.Type.EXACT)) {
-                    termslist.add(queryTerm.term.bytes());
-                } else {
-                    termslist.add(queryTerm.term.bytes());
+                    return hash;
+                });
+            } else {
+                BytesRefHash termslist = fieldTerms.computeIfAbsent(queryTerm.term.field(), f -> new BytesRefHash());
+                termslist.add(queryTerm.term.bytes());
+                if (!queryTerm.type.equals(QueryTerm.Type.EXACT)) {
                     for (PresearcherComponent component : components) {
                         BytesRef extratoken = component.extraToken(queryTerm);
                         if (extratoken != null)

--- a/luwak/src/main/java/uk/co/flax/luwak/presearcher/WildcardNGramPresearcherComponent.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/presearcher/WildcardNGramPresearcherComponent.java
@@ -1,6 +1,6 @@
 package uk.co.flax.luwak.presearcher;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 import org.apache.lucene.analysis.TokenStream;
@@ -66,7 +66,7 @@ public class WildcardNGramPresearcherComponent extends PresearcherComponent {
         this.ngramSuffix = ngramSuffix;
         this.maxTokenSize = maxTokenSize;
         this.wildcardToken = wildcardToken;
-        this.excludedFields = excludedFields == null ? new HashSet<>() : excludedFields;
+        this.excludedFields = excludedFields == null ? Collections.emptySet() : excludedFields;
     }
 
     /**

--- a/luwak/src/main/java/uk/co/flax/luwak/termextractor/weights/TermFrequencyWeightPolicy.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/termextractor/weights/TermFrequencyWeightPolicy.java
@@ -45,8 +45,9 @@ public class TermFrequencyWeightPolicy extends WeightPolicy {
 
     @Override
     public float weighTerm(QueryTerm term) {
-        if (this.frequencies.containsKey(term.term.text()))
-            return (n / this.frequencies.get(term.term.text())) + k;
+        Integer mapVal = this.frequencies.get(term.term.text());
+        if (mapVal != null)
+            return (n / mapVal) + k;
         return 1;
     }
 

--- a/luwak/src/main/java/uk/co/flax/luwak/termextractor/weights/TermWeightPolicy.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/termextractor/weights/TermWeightPolicy.java
@@ -30,8 +30,9 @@ public class TermWeightPolicy extends WeightPolicy {
 
     @Override
     public float weighTerm(QueryTerm term) {
-        if (this.terms.containsKey(term.term.text()))
-            return this.terms.get(term.term.text());
+        Float weight = this.terms.get(term.term.text());
+        if (weight != null)
+            return weight;
         return 1;
     }
 

--- a/luwak/src/main/java/uk/co/flax/luwak/util/SpanRewriter.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/util/SpanRewriter.java
@@ -105,10 +105,8 @@ public class SpanRewriter {
             PrefixCodedTerms.TermIterator it = terms.iterator();
             for (int i = 0; i < terms.size(); i++) {
                 BytesRef term = BytesRef.deepCopyOf(it.next());
-                if (spanQueries.containsKey(it.field()) == false) {
-                    spanQueries.put(it.field(), new ArrayList<>());
-                }
-                spanQueries.get(it.field()).add(new SpanTermQuery(new Term(it.field(), term)));
+                List<SpanTermQuery> termQueryList = spanQueries.computeIfAbsent(it.field(), f -> new ArrayList<>());
+                termQueryList.add(new SpanTermQuery(new Term(it.field(), term)));
             }
             BooleanQuery.Builder builder = new BooleanQuery.Builder();
             for (Map.Entry<String,List<SpanTermQuery>> entry : spanQueries.entrySet()) {


### PR DESCRIPTION
There are many chains of map.containsKey -> map.get() being used, and this can be simplified with .computeIfAbsent.

Also found were double computations of values that aren't great candidates for computeIfAbsent, and another change replacing an empty new LinkedList with Collections.emptyList.