### PR TITLE
IndexSearcher created over DocumentBatch should not use a query cache

### DIFF
--- a/luwak/src/main/java/uk/co/flax/luwak/DocumentBatch.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/DocumentBatch.java
@@ -158,6 +158,7 @@ public abstract class DocumentBatch implements Closeable, Iterable<InputDocument
     public IndexSearcher getSearcher() throws IOException {
         IndexSearcher searcher = new IndexSearcher(getIndexReader());
         searcher.setSimilarity(similarity);
+        searcher.setQueryCache(null);
         return searcher;
     }
 


### PR DESCRIPTION
QueryCache is explicitly set to null from MemoryIndex's createSearcher but this is missing from DocumentBatch getSearcher - this adds the setQueryCache(null).