### PR TITLE
needScores can be false for QueryIndex, SimpleMatcher.

### DIFF
--- a/luwak/src/main/java/uk/co/flax/luwak/QueryIndex.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/QueryIndex.java
@@ -256,7 +256,7 @@ class QueryIndex {
 
         @Override
         public boolean needsScores() {
-            return true;
+            return false;
         }
 
     }

--- a/luwak/src/main/java/uk/co/flax/luwak/matchers/SimpleMatcher.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/matchers/SimpleMatcher.java
@@ -39,6 +39,24 @@ public class SimpleMatcher extends CollectingMatcher<QueryMatch> {
         return new QueryMatch(queryId, docId);
     }
 
+
+    @Override
+    protected MatchCollector buildMatchCollector(String queryId) {
+        return new SimpleMatchCollector(queryId);
+    }
+
+
     public static final MatcherFactory<QueryMatch> FACTORY = SimpleMatcher::new;
 
+
+    private class SimpleMatchCollector extends MatchCollector {
+        public SimpleMatchCollector(String queryId) {
+            super(queryId);
+        }
+
+        @Override
+        public boolean needsScores() {
+            return false;
+        }
+    }
 }

--- a/luwak/src/test/java/uk/co/flax/luwak/matchers/TestSimpleMatcher.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/matchers/TestSimpleMatcher.java
@@ -1,0 +1,27 @@
+package uk.co.flax.luwak.matchers;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.junit.Test;
+import uk.co.flax.luwak.*;
+import uk.co.flax.luwak.presearcher.MatchAllPresearcher;
+import uk.co.flax.luwak.queryparsers.LuceneQueryParser;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestSimpleMatcher {
+
+    @Test
+    public void testSimpleMatcher() throws IOException, UpdateException {
+
+        try (Monitor monitor = new Monitor(new LuceneQueryParser("field"), new MatchAllPresearcher())) {
+            monitor.update(new MonitorQuery("1", "test"), new MonitorQuery("2", "wibble"));
+
+            InputDocument doc1 = InputDocument.builder("doc1").addField("field", "test", new StandardAnalyzer()).build();
+
+            Matches<QueryMatch> matches = monitor.match(doc1, SimpleMatcher.FACTORY);
+            assertThat(matches.matches("1", "doc1")).isNotNull();
+        }
+    }
+}


### PR DESCRIPTION
QueryIndex's ordinary collector and SimpleMatcher's collector do not require needScores to be true given that they don't need to retrieve scores of matches or extract Spans. This PR includes this change plus a basic test for SimpleMatcher, which did not have one before.