### PR TITLE
Fix correctness of MatchAllDocsQuery handling

### DIFF
--- a/luwak/src/main/java/uk/co/flax/luwak/termextractor/treebuilder/BooleanQueryTreeBuilder.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/termextractor/treebuilder/BooleanQueryTreeBuilder.java
@@ -46,9 +46,6 @@ public class BooleanQueryTreeBuilder extends QueryTreeBuilder<BooleanQuery> {
     protected Clauses analyze(BooleanQuery query) {
         Clauses clauses = new Clauses();
         for (BooleanClause clause : query) {
-            if (clause.getQuery() instanceof MatchAllDocsQuery) {
-                continue;       // ignored for term extraction
-            }
             if (clause.getOccur() == BooleanClause.Occur.MUST || clause.getOccur() == BooleanClause.Occur.FILTER) {
                 clauses.conjunctions.add(clause.getQuery());
             }

--- a/luwak/src/test/java/uk/co/flax/luwak/termextractor/TestBooleanTermExtractor.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/termextractor/TestBooleanTermExtractor.java
@@ -2,8 +2,16 @@ package uk.co.flax.luwak.termextractor;
 
 import java.util.List;
 
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
+import org.assertj.core.api.Condition;
 import org.junit.Test;
+import uk.co.flax.luwak.termextractor.querytree.AnyNode;
 import uk.co.flax.luwak.testutils.ParserUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -83,6 +91,60 @@ public class TestBooleanTermExtractor {
         assertThat(treeBuilder.collectTerms(q))
                 .containsOnly(new QueryTerm("field1", "term1", QueryTerm.Type.EXACT));
 
+    }
+
+    @Test
+    public void testMatchAllDocsIsOnlyQuery() throws Exception {
+        // Set up - single MatchAllDocsQuery clause in a BooleanQuery
+        Query q = ParserUtils.parse("+*:*");
+        assertThat(q).isInstanceOf(BooleanQuery.class);
+        BooleanClause clause = Iterables.getOnlyElement((BooleanQuery)q);
+        assertThat(clause.getQuery()).isInstanceOf(MatchAllDocsQuery.class);
+        assertThat(clause.getOccur()).isSameAs(BooleanClause.Occur.MUST);
+
+        List<QueryTerm> terms = treeBuilder.collectTerms(q);
+        assertThat(terms).hasSize(1);
+        assertThat(terms.get(0).type).isSameAs(QueryTerm.Type.ANY);
+    }
+
+    @Test
+    public void testMatchAllDocsMustWithKeywordShould() throws Exception {
+        Query q = ParserUtils.parse("+*:* field1:term1");
+        // Because field1:term1 is optional, only the MatchAllDocsQuery is collected.
+        List<QueryTerm> terms = treeBuilder.collectTerms(q);
+        assertThat(terms).hasSize(1);
+        assertThat(terms.get(0).type).isSameAs(QueryTerm.Type.ANY);
+    }
+
+    @Test
+    public void testMatchAllDocsMustWithKeywordNot() throws Exception {
+        Query q = ParserUtils.parse("+*:* -field1:notterm");
+
+        // Because field1:notterm is negated, only the mandatory MatchAllDocsQuery is collected.
+        List<QueryTerm> terms = treeBuilder.collectTerms(q);
+        assertThat(terms).hasSize(1);
+        assertThat(terms.get(0).type).isSameAs(QueryTerm.Type.ANY);
+    }
+
+    @Test
+    public void testMatchAllDocsMustWithKeywordShouldAndKeywordNot() throws Exception {
+        Query q = ParserUtils.parse("+*:* field1:term1 -field2:notterm");
+
+        // Because field1:notterm is negated and field1:term1 is optional, only the mandatory MatchAllDocsQuery is collected.
+        List<QueryTerm> terms = treeBuilder.collectTerms(q);
+        assertThat(terms).hasSize(1);
+        assertThat(terms.get(0).type).isSameAs(QueryTerm.Type.ANY);
+    }
+
+    @Test
+    public void testMatchAllDocsMustAndOtherMustWithKeywordShouldAndKeywordNot() throws Exception {
+        Query q = ParserUtils.parse("+*:* +field9:term9 field1:term1 -field2:notterm");
+
+        // The queryterm collected by weight is the non-anynode, so field9:term9 shows up before MatchAllDocsQuery.
+        List<QueryTerm> terms = treeBuilder.collectTerms(q);
+        assertThat(terms).hasSize(1);
+        assertThat(terms.get(0).type).isSameAs(QueryTerm.Type.EXACT);
+        assertThat(terms.get(0).term).isEqualTo(new Term("field9", "term9"));
     }
 
 }


### PR DESCRIPTION
MatchAllDocsQuery handling under the BooleanQueryTreeBuilder breaks under certain circumstances - added tests to illustrate, all are fixed by removing the explicit handling of this query type.