### PR TITLE
Move out FieldFilterPresearcherComponent tests so that mvn runs them

### DIFF
--- a/luwak/src/test/java/uk/co/flax/luwak/presearcher/FieldFilterPresearcherComponentTestBase.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/presearcher/FieldFilterPresearcherComponentTestBase.java
@@ -30,22 +30,6 @@ import static uk.co.flax.luwak.assertions.MatchesAssert.assertThat;
  */
 public abstract class FieldFilterPresearcherComponentTestBase extends PresearcherTestBase {
 
-    public static class TestTermFiltered extends FieldFilterPresearcherComponentTestBase {
-
-        @Override
-        protected Presearcher createPresearcher() {
-            return new TermFilteredPresearcher(new FieldFilterPresearcherComponent("language"));
-        }
-    }
-
-    public static class TestMultipass extends FieldFilterPresearcherComponentTestBase {
-
-        @Override
-        protected Presearcher createPresearcher() {
-            return new MultipassTermFilteredPresearcher(2, 0.0f, new FieldFilterPresearcherComponent("language"));
-        }
-    }
-
     public static final Analyzer ANALYZER = new StandardAnalyzer();
 
     @Test

--- a/luwak/src/test/java/uk/co/flax/luwak/presearcher/TestMultipass.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/presearcher/TestMultipass.java
@@ -1,0 +1,11 @@
+package uk.co.flax.luwak.presearcher;
+
+import uk.co.flax.luwak.Presearcher;
+
+public class TestMultipass extends FieldFilterPresearcherComponentTestBase {
+
+    @Override
+    protected Presearcher createPresearcher() {
+        return new MultipassTermFilteredPresearcher(2, 0.0f, new FieldFilterPresearcherComponent("language"));
+    }
+}

--- a/luwak/src/test/java/uk/co/flax/luwak/presearcher/TestTermFiltered.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/presearcher/TestTermFiltered.java
@@ -1,0 +1,11 @@
+package uk.co.flax.luwak.presearcher;
+
+import uk.co.flax.luwak.Presearcher;
+
+public class TestTermFiltered extends FieldFilterPresearcherComponentTestBase {
+
+    @Override
+    protected Presearcher createPresearcher() {
+        return new TermFilteredPresearcher(new FieldFilterPresearcherComponent("language"));
+    }
+}


### PR DESCRIPTION
This just ensures that mvn sees the classes to run them, they still fail on master, (But work on branch 1.4.x)