### PR TITLE
Removing unused imports

### DIFF
--- a/benchmark/src/main/java/uk/co/flax/luwak/benchmark/StandardBenchmark.java
+++ b/benchmark/src/main/java/uk/co/flax/luwak/benchmark/StandardBenchmark.java
@@ -35,7 +35,6 @@ import uk.co.flax.luwak.presearcher.MultipassTermFilteredPresearcher;
 import uk.co.flax.luwak.presearcher.TermFilteredPresearcher;
 import uk.co.flax.luwak.presearcher.WildcardNGramPresearcherComponent;
 import uk.co.flax.luwak.queryparsers.LuceneQueryParser;
-import uk.co.flax.luwak.termextractor.weights.TermWeightor;
 
 public class StandardBenchmark {
 

--- a/benchmark/src/test/java/uk/co/flax/luwak/benchmark/TestBenchmark.java
+++ b/benchmark/src/test/java/uk/co/flax/luwak/benchmark/TestBenchmark.java
@@ -30,7 +30,6 @@ import uk.co.flax.luwak.*;
 import uk.co.flax.luwak.matchers.SimpleMatcher;
 import uk.co.flax.luwak.presearcher.TermFilteredPresearcher;
 import uk.co.flax.luwak.queryparsers.LuceneQueryParser;
-import uk.co.flax.luwak.termextractor.weights.TermWeightor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/luwak/src/main/java/uk/co/flax/luwak/termextractor/QueryTreeBuilder.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/termextractor/QueryTreeBuilder.java
@@ -4,8 +4,6 @@ import org.apache.lucene.search.Query;
 import uk.co.flax.luwak.termextractor.querytree.QueryTree;
 import uk.co.flax.luwak.termextractor.weights.TermWeightor;
 
-import java.util.function.ToDoubleFunction;
-
 /*
  * Copyright (c) 2013 Lemur Consulting Ltd.
  * <p/>

--- a/luwak/src/main/java/uk/co/flax/luwak/termextractor/querytree/ConjunctionNode.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/termextractor/querytree/ConjunctionNode.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.lucene.util.PriorityQueue;
 import uk.co.flax.luwak.termextractor.QueryTerm;
 
 /*

--- a/luwak/src/main/java/uk/co/flax/luwak/termextractor/querytree/DisjunctionNode.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/termextractor/querytree/DisjunctionNode.java
@@ -3,11 +3,9 @@ package uk.co.flax.luwak.termextractor.querytree;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import uk.co.flax.luwak.termextractor.QueryTerm;
 

--- a/luwak/src/main/java/uk/co/flax/luwak/termextractor/querytree/QueryTree.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/termextractor/querytree/QueryTree.java
@@ -1,7 +1,5 @@
 package uk.co.flax.luwak.termextractor.querytree;
 
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 
 import uk.co.flax.luwak.termextractor.QueryTerm;

--- a/luwak/src/main/java/uk/co/flax/luwak/termextractor/querytree/TermNode.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/termextractor/querytree/TermNode.java
@@ -1,9 +1,6 @@
 package uk.co.flax.luwak.termextractor.querytree;
 
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.function.ToDoubleFunction;
 
 import org.apache.lucene.index.Term;
 import uk.co.flax.luwak.termextractor.QueryTerm;

--- a/luwak/src/test/java/uk/co/flax/luwak/TestMonitorFlexibleLuceneQueryParser.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/TestMonitorFlexibleLuceneQueryParser.java
@@ -2,44 +2,20 @@ package uk.co.flax.luwak;
 
 import java.io.IOException;
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
-import org.apache.lucene.analysis.core.WhitespaceTokenizer;
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.IntPoint;
-import org.apache.lucene.search.Query;
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 
-import junit.framework.Assert;
 import uk.co.flax.luwak.matchers.SimpleMatcher;
 import uk.co.flax.luwak.presearcher.MatchAllPresearcher;
-import uk.co.flax.luwak.queryparsers.LuceneQueryParser;
 import uk.co.flax.luwak.queryparsers.FlexibleLuceneQueryParser;
 
-import org.apache.lucene.index.memory.MemoryIndex;
-import org.apache.lucene.queryparser.classic.QueryParser;
-import org.apache.lucene.queryparser.flexible.standard.StandardQueryParser;
 import org.apache.lucene.queryparser.flexible.standard.config.PointsConfig;
-import org.apache.lucene.analysis.core.SimpleAnalyzer;
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.apache.lucene.document.StoredField;
-import org.apache.lucene.document.TextField;
-import org.apache.lucene.document.Field.Store;
-import org.apache.lucene.document.Document;
-import org.apache.lucene.document.Field;
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.BooleanClause.Occur;
-import org.apache.lucene.search.BooleanQuery.Builder;
 
 import static uk.co.flax.luwak.assertions.MatchesAssert.assertThat;
 

--- a/luwak/src/test/java/uk/co/flax/luwak/TestMonitorPersistence.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/TestMonitorPersistence.java
@@ -14,7 +14,6 @@ import org.junit.Test;
 import uk.co.flax.luwak.matchers.SimpleMatcher;
 import uk.co.flax.luwak.presearcher.TermFilteredPresearcher;
 import uk.co.flax.luwak.queryparsers.LuceneQueryParser;
-import uk.co.flax.luwak.termextractor.weights.TermWeightor;
 import uk.co.flax.luwak.testutils.FileUtils;
 
 import static uk.co.flax.luwak.assertions.MatchesAssert.assertThat;

--- a/luwak/src/test/java/uk/co/flax/luwak/demo/LuwakDemo.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/demo/LuwakDemo.java
@@ -22,7 +22,6 @@ import uk.co.flax.luwak.matchers.HighlightingMatcher;
 import uk.co.flax.luwak.matchers.HighlightsMatch;
 import uk.co.flax.luwak.presearcher.TermFilteredPresearcher;
 import uk.co.flax.luwak.queryparsers.LuceneQueryParser;
-import uk.co.flax.luwak.termextractor.weights.TermWeightor;
 
 /*
  * Copyright (c) 2013 Lemur Consulting Ltd.

--- a/luwak/src/test/java/uk/co/flax/luwak/presearcher/FieldFilterPresearcherComponentTestBase.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/presearcher/FieldFilterPresearcherComponentTestBase.java
@@ -9,7 +9,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import uk.co.flax.luwak.*;
 import uk.co.flax.luwak.matchers.SimpleMatcher;
-import uk.co.flax.luwak.termextractor.weights.TermWeightor;
 
 import static org.assertj.core.api.Fail.fail;
 import static uk.co.flax.luwak.assertions.MatchesAssert.assertThat;

--- a/luwak/src/test/java/uk/co/flax/luwak/presearcher/TestFieldFilteredMultipassPresearcher.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/presearcher/TestFieldFilteredMultipassPresearcher.java
@@ -1,7 +1,6 @@
 package uk.co.flax.luwak.presearcher;
 
 import uk.co.flax.luwak.Presearcher;
-import uk.co.flax.luwak.termextractor.weights.TermWeightor;
 
 public class TestFieldFilteredMultipassPresearcher extends FieldFilterPresearcherComponentTestBase {
 

--- a/luwak/src/test/java/uk/co/flax/luwak/presearcher/TestFieldTermFilteredPresearcher.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/presearcher/TestFieldTermFilteredPresearcher.java
@@ -1,7 +1,6 @@
 package uk.co.flax.luwak.presearcher;
 
 import uk.co.flax.luwak.Presearcher;
-import uk.co.flax.luwak.termextractor.weights.TermWeightor;
 
 public class TestFieldTermFilteredPresearcher extends FieldFilterPresearcherComponentTestBase {
 

--- a/luwak/src/test/java/uk/co/flax/luwak/presearcher/TestPresearcherMatchCollector.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/presearcher/TestPresearcherMatchCollector.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 import uk.co.flax.luwak.*;
 import uk.co.flax.luwak.matchers.SimpleMatcher;
 import uk.co.flax.luwak.queryparsers.LuceneQueryParser;
-import uk.co.flax.luwak.termextractor.weights.TermWeightor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/luwak/src/test/java/uk/co/flax/luwak/presearcher/TestWildcardTermPresearcher.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/presearcher/TestWildcardTermPresearcher.java
@@ -14,7 +14,6 @@ import uk.co.flax.luwak.Presearcher;
 import uk.co.flax.luwak.UpdateException;
 import uk.co.flax.luwak.assertions.TokenStreamAssert;
 import uk.co.flax.luwak.matchers.SimpleMatcher;
-import uk.co.flax.luwak.termextractor.weights.TermWeightor;
 
 import static uk.co.flax.luwak.assertions.MatchesAssert.assertThat;
 

--- a/luwak/src/test/java/uk/co/flax/luwak/termextractor/TestBooleanTermExtractor.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/termextractor/TestBooleanTermExtractor.java
@@ -4,17 +4,16 @@ import java.util.List;
 import java.util.Set;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
-import org.assertj.core.api.Condition;
 import org.junit.Test;
 import uk.co.flax.luwak.termextractor.querytree.AnyNode;
 import uk.co.flax.luwak.termextractor.weights.TermWeightor;
 import uk.co.flax.luwak.termextractor.weights.TokenLengthNorm;
+import uk.co.flax.luwak.termextractor.querytree.AnyNode;
 import uk.co.flax.luwak.testutils.ParserUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/luwak/src/test/java/uk/co/flax/luwak/termextractor/TestBooleanTermExtractor.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/termextractor/TestBooleanTermExtractor.java
@@ -1,19 +1,15 @@
 package uk.co.flax.luwak.termextractor;
 
-import java.util.List;
 import java.util.Set;
 
 import com.google.common.collect.Iterables;
-import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.junit.Test;
-import uk.co.flax.luwak.termextractor.querytree.AnyNode;
 import uk.co.flax.luwak.termextractor.weights.TermWeightor;
 import uk.co.flax.luwak.termextractor.weights.TokenLengthNorm;
-import uk.co.flax.luwak.termextractor.querytree.AnyNode;
 import uk.co.flax.luwak.testutils.ParserUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/luwak/src/test/java/uk/co/flax/luwak/termextractor/TestQueryTermComparators.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/termextractor/TestQueryTermComparators.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import com.google.common.collect.ImmutableMap;
 import org.apache.lucene.index.Term;
 import org.junit.Test;
-import org.mockito.internal.util.collections.Sets;
 import uk.co.flax.luwak.termextractor.querytree.AnyNode;
 import uk.co.flax.luwak.termextractor.querytree.ConjunctionNode;
 import uk.co.flax.luwak.termextractor.querytree.DisjunctionNode;


### PR DESCRIPTION
Not strictly related to Lucene 7, but discovered as part of my porting work, just removes a bunch of redundant imports.