### PR TITLE
Replacing RandomAccessWeight

### DIFF
--- a/luwak/src/test/java/uk/co/flax/luwak/TestSlowLog.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/TestSlowLog.java
@@ -53,7 +53,7 @@ public class TestSlowLog {
                         } catch (InterruptedException e) {
                             throw new RuntimeException(e);
                         }
-                        return new ConstantScoreWeight(this, boost) {
+                        return new ConstantScoreWeight(this) {
                             @Override
                             public final Scorer scorer(LeafReaderContext context) throws IOException {
                               final Bits matchingDocs = getMatchingDocs(context);
@@ -81,11 +81,6 @@ public class TestSlowLog {
 
                             protected Bits getMatchingDocs(LeafReaderContext context) throws IOException {
                                 return new Bits.MatchAllBits(context.reader().maxDoc());
-                            }
-
-                            @Override
-                            public boolean isCacheable(LeafReaderContext ctx) {
-                              return true;
                             }
 
                             public String toString() {


### PR DESCRIPTION
RandomAccessWeight is no longer available in Lucene 7, so removing its use (whilst still retaining the Lucene 6 API) as a pre-cursor to porting to 7.