### PR TITLE
Remove use of LegacyNumeric stuff

### DIFF
--- a/luwak/src/test/java/uk/co/flax/luwak/termextractor/TestExtractors.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/termextractor/TestExtractors.java
@@ -1,6 +1,7 @@
 package uk.co.flax.luwak.termextractor;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.TermsQuery;
 import org.apache.lucene.search.*;
@@ -54,7 +55,7 @@ public class TestExtractors {
     @SuppressWarnings("deprecation")
     public void testRangeQueriesReturnAnyToken() {
 
-        LegacyNumericRangeQuery<Long> nrq = LegacyNumericRangeQuery.newLongRange("field", 0l, 10l, true, true);
+        Query nrq = LongPoint.newRangeQuery("field", 0L, 10L);
 
         assertThat(treeBuilder.collectTerms(nrq))
                 .hasSize(1)


### PR DESCRIPTION
LegacyNumeric is removed in Lucene 7, so this is a pre-requisite for porting to that.
The tests pass with these changes, but don't if I make the TermsQuery changes as well, so I might have missed something vital here...