### PR TITLE
Presearcher debugger requires scores when collecting

### DIFF
--- a/luwak/src/main/java/uk/co/flax/luwak/Monitor.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/Monitor.java
@@ -619,6 +619,11 @@ public class Monitor implements Closeable {
         }
 
         @Override
+        public boolean needsScores() {
+            return true;
+        }
+
+        @Override
         public void matchQuery(final String id, QueryCacheEntry query, QueryIndex.DataValues dataValues) throws IOException {
 
             SpanCollector collector = new SpanCollector() {

--- a/luwak/src/main/java/uk/co/flax/luwak/QueryIndex.java
+++ b/luwak/src/main/java/uk/co/flax/luwak/QueryIndex.java
@@ -206,6 +206,10 @@ class QueryIndex {
 
         void matchQuery(String id, QueryCacheEntry query, DataValues dataValues) throws IOException;
 
+        default boolean needsScores() {
+            return false;
+        }
+
     }
 
     // ---------------------------------------------
@@ -257,7 +261,7 @@ class QueryIndex {
 
         @Override
         public boolean needsScores() {
-            return false;
+            return matcher.needsScores();
         }
 
     }

--- a/luwak/src/test/java/uk/co/flax/luwak/presearcher/FieldFilterPresearcherComponentTestBase.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/presearcher/FieldFilterPresearcherComponentTestBase.java
@@ -30,22 +30,6 @@ import static uk.co.flax.luwak.assertions.MatchesAssert.assertThat;
  */
 public abstract class FieldFilterPresearcherComponentTestBase extends PresearcherTestBase {
 
-    public static class TestTermFiltered extends FieldFilterPresearcherComponentTestBase {
-
-        @Override
-        protected Presearcher createPresearcher() {
-            return new TermFilteredPresearcher(new FieldFilterPresearcherComponent("language"));
-        }
-    }
-
-    public static class TestMultipass extends FieldFilterPresearcherComponentTestBase {
-
-        @Override
-        protected Presearcher createPresearcher() {
-            return new MultipassTermFilteredPresearcher(2, 0.0f, new FieldFilterPresearcherComponent("language"));
-        }
-    }
-
     public static final Analyzer ANALYZER = new StandardAnalyzer();
 
     @Test

--- a/luwak/src/test/java/uk/co/flax/luwak/presearcher/TestFieldFilteredMultipassPresearcher.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/presearcher/TestFieldFilteredMultipassPresearcher.java
@@ -1,0 +1,11 @@
+package uk.co.flax.luwak.presearcher;
+
+import uk.co.flax.luwak.Presearcher;
+
+public class TestFieldFilteredMultipassPresearcher extends FieldFilterPresearcherComponentTestBase {
+
+    @Override
+    protected Presearcher createPresearcher() {
+        return new MultipassTermFilteredPresearcher(2, 0.0f, new FieldFilterPresearcherComponent("language"));
+    }
+}

--- a/luwak/src/test/java/uk/co/flax/luwak/presearcher/TestFieldTermFilteredPresearcher.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/presearcher/TestFieldTermFilteredPresearcher.java
@@ -1,0 +1,11 @@
+package uk.co.flax.luwak.presearcher;
+
+import uk.co.flax.luwak.Presearcher;
+
+public class TestFieldTermFilteredPresearcher extends FieldFilterPresearcherComponentTestBase {
+
+    @Override
+    protected Presearcher createPresearcher() {
+        return new TermFilteredPresearcher(new FieldFilterPresearcherComponent("language"));
+    }
+}


### PR DESCRIPTION
The presearcher debugger uses Span highlighting to collect matching terms,
and as such needs scores to be enabled.

Also fixes an issue with maven not running some nested test classes, by
moving them to top level.

Fixes #164