### PR TITLE
Fix brittle test testParallelSlowLog()

### DIFF
--- a/luwak/src/test/java/uk/co/flax/luwak/matchers/ConcurrentMatcherTestBase.java
+++ b/luwak/src/test/java/uk/co/flax/luwak/matchers/ConcurrentMatcherTestBase.java
@@ -112,7 +112,7 @@ public abstract class ConcurrentMatcherTestBase {
             Matches<QueryMatch> matches = monitor.match(batch, factory);
             assertThat(matches.getMatchCount("doc1"))
                     .isEqualTo(3);
-            assertThat(matches.getSlowLog().toString())
+            assertThat(monitor.match(batch, factory).getSlowLog().toString())
                 .contains("1 [")
                 .contains("3 [")
                 .doesNotContain("2 [");


### PR DESCRIPTION
Fixes #192
The test ConcurrentMatcherTestBase.testParallelSlowLog() fails when run on its own but passes if it is run along with the other tests in the class. 
The test passes independently when this change is made - calling getSlowLog() directly on `monitor.match(batch, factory)` without using the `Matches<QueryMatch> matches` object.

Open to discuss other approaches to fix this test so that it can pass when run on its own.

Command used to run the test:
`
mvn test -Dtest=uk.co.flax.luwak.matchers.TestParallelMatcher#testParallelSlowLog -DfailIfNoTests=false
`
